### PR TITLE
feat: Phase 2 simulation — step-by-step tectonics, Wilson Cycle, rift edges, boundary viz, timeline UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.worktrees/
+__pycache__/
+*.pyc
+*.pyo
+.env
+venv/
+*.egg-info/
+src/web/data/

--- a/src/server/grid_export.py
+++ b/src/server/grid_export.py
@@ -64,12 +64,23 @@ def export_grid(level: int = 6, output_path: str = None, force: bool = False) ->
     # --- Adjacency: per-cell neighbour indices (sorted ascending) ---
     adjacency = grid._adjacency  # list of sorted int lists
 
+    # Build unique edge list: [[cell_a, cell_b], ...] where cell_a < cell_b
+    print('Building edge list...')
+    edge_set = set()
+    edges_out = []
+    for i, neighbors in enumerate(adjacency):
+        for j in neighbors:
+            if j > i:
+                edge_set.add((i, j))
+                edges_out.append([i, j])
+
     payload = {
         'cell_count': grid.cell_count,
         'level': level,
         'vertices': verts,
         'faces': faces,
         'adjacency': adjacency,
+        'edges': edges_out,
     }
 
     print(f'Writing {output_path}...')

--- a/src/server/grid_export.py
+++ b/src/server/grid_export.py
@@ -2,11 +2,11 @@
 grid_export.py — Export geodesic grid to JSON for Three.js consumption.
 
 Produces src/web/data/grid_level{N}.json with vertices, faces, adjacency, and edges.
-For level 6 (~40k cells): ~29 MB JSON, ~8 MB gzipped.
+For level 7 (~163k cells): ~110 MB JSON, ~29 MB gzipped.
 Cached: only regenerates if the output file is missing.
 
 Usage:
-    python grid_export.py              # level 6 (default)
+    python grid_export.py              # level 7 (default)
     python grid_export.py --level 4   # smaller grid for dev/testing
 """
 
@@ -25,12 +25,12 @@ sys.path.insert(0, _GRID_DIR)
 from geodesic_grid import GeodesicGrid
 
 
-def export_grid(level: int = 6, output_path: str = None, force: bool = False) -> str:
+def export_grid(level: int = 7, output_path: str = None, force: bool = False) -> str:
     """
     Build and export the geodesic grid to JSON.
 
     Args:
-        level: Subdivision level (default 6 → 40,962 cells)
+        level: Subdivision level (default 7 → 163,842 cells)
         output_path: Where to write the JSON. Defaults to
                      src/web/data/grid_level{level}.json
         force: Regenerate even if output already exists

--- a/src/server/grid_export.py
+++ b/src/server/grid_export.py
@@ -1,7 +1,8 @@
 """
 grid_export.py — Export geodesic grid to JSON for Three.js consumption.
 
-Produces src/web/data/grid_level6.json (~2.5 MB, ~800 KB gzipped).
+Produces src/web/data/grid_level{N}.json with vertices, faces, adjacency, and edges.
+For level 6 (~40k cells): ~29 MB JSON, ~8 MB gzipped.
 Cached: only regenerates if the output file is missing.
 
 Usage:
@@ -65,13 +66,12 @@ def export_grid(level: int = 6, output_path: str = None, force: bool = False) ->
     adjacency = grid._adjacency  # list of sorted int lists
 
     # Build unique edge list: [[cell_a, cell_b], ...] where cell_a < cell_b
+    # Edges exported for rift edge tool in Three.js globe UI
     print('Building edge list...')
-    edge_set = set()
     edges_out = []
     for i, neighbors in enumerate(adjacency):
         for j in neighbors:
             if j > i:
-                edge_set.add((i, j))
                 edges_out.append([i, j])
 
     payload = {

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -59,6 +59,7 @@ _sim_lock = threading.Lock()
 # Step-by-step session state
 _session: dict = {
     'active':        False,
+    'stepping':      False,  # True while a /api/sim/step call is executing
     'cells':         None,
     'plates':        None,
     'grid':          None,
@@ -83,7 +84,7 @@ async def get_grid():
     # Generate on first request if missing
     if not gz_path.exists():
         _DATA_DIR.mkdir(parents=True, exist_ok=True)
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(
             None,
             lambda: grid_export.export_grid(level=_GRID_LEVEL)
@@ -230,6 +231,7 @@ async def sim_init(req: SimInitRequest):
 
     with _session_lock:
         _session['active']       = True
+        _session['stepping']     = False
         _session['cells']        = cells
         _session['plates']       = plates
         _session['grid']         = grid
@@ -248,6 +250,9 @@ async def sim_step(req: SimStepRequest):
     with _session_lock:
         if not _session['active']:
             raise HTTPException(status_code=400, detail='No active session. Call /api/sim/init first.')
+        if _session['stepping']:
+            raise HTTPException(status_code=409, detail='Step already in progress.')
+        _session['stepping'] = True
         cells      = _session['cells']
         plates     = _session['plates']
         grid       = _session['grid']
@@ -256,15 +261,17 @@ async def sim_step(req: SimStepRequest):
         t          = _session['current_time']
         last_rift  = _session['last_rift_ma']
 
-    boundaries = []
-    for _ in range(req.steps):
-        boundaries, last_rift = sim_runner.step_once(
-            cells, plates, grid, dt, t, last_rift)
-        t += dt
-
-    with _session_lock:
-        _session['current_time'] = t
-        _session['last_rift_ma'] = last_rift
+    try:
+        boundaries = []
+        for _ in range(req.steps):
+            boundaries, last_rift = sim_runner.step_once(
+                cells, plates, grid, dt, t, last_rift)
+            t += dt
+    finally:
+        with _session_lock:
+            _session['current_time'] = t
+            _session['last_rift_ma'] = last_rift
+            _session['stepping'] = False
 
     snapshot = sim_runner.build_snapshot(cells, grid, co2_ppm, t, boundaries)
     return JSONResponse(content=snapshot)
@@ -291,7 +298,7 @@ async def startup():
     gz_path = _DATA_DIR / f'grid_level{_GRID_LEVEL}.json.gz'
     if not gz_path.exists():
         print(f'Pre-generating grid JSON (level {_GRID_LEVEL})...')
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(
             None,
             lambda: grid_export.export_grid(level=_GRID_LEVEL)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -41,7 +41,7 @@ app = FastAPI(title='GeoForge API', version='1.0')
 
 _WEB_DIR  = _SCRIPT_DIR / '..' / 'web'
 _DATA_DIR = _WEB_DIR / 'data'
-_GRID_LEVEL = 6
+_GRID_LEVEL = 7
 
 # ============================================================================
 # Simulation state (one sim at a time)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -56,6 +56,19 @@ _sim_state = {
 }
 _sim_lock = threading.Lock()
 
+# Step-by-step session state
+_session: dict = {
+    'active':        False,
+    'cells':         None,
+    'plates':        None,
+    'grid':          None,
+    'current_time':  0.0,
+    'co2_ppm':       400.0,
+    'timestep_ma':   10.0,
+    'last_rift_ma':  0.0,
+}
+_session_lock = threading.Lock()
+
 
 # ============================================================================
 # Grid endpoint
@@ -98,6 +111,21 @@ async def get_grid():
 # ============================================================================
 # Simulation endpoints
 # ============================================================================
+
+class SimInitRequest(BaseModel):
+    continental_cells: List[int] = []
+    craton_cells:      List[int] = []
+    rift_edges:        List[List[int]] = []  # [[cell_a, cell_b], ...]
+    seed:        int   = 42
+    co2_ppm:     float = 400.0
+    num_plates:  int   = 7
+    grid_level:  int   = 7
+    timestep_ma: float = 10.0
+
+
+class SimStepRequest(BaseModel):
+    steps: int = 1
+
 
 class SimRequest(BaseModel):
     continental_cells: List[int] = []
@@ -180,6 +208,77 @@ async def get_status():
 @app.get('/api/health')
 async def health():
     return {'status': 'ok', 'grid_level': _GRID_LEVEL}
+
+
+# ============================================================================
+# Step-by-step simulation endpoints
+# ============================================================================
+
+@app.post('/api/sim/init')
+async def sim_init(req: SimInitRequest):
+    """Initialise a step-by-step simulation session."""
+    grid = sim_runner.get_grid(req.grid_level)
+
+    cells, plates = sim_runner.initialize_cells(
+        grid,
+        continental_cells=req.continental_cells,
+        craton_cells=req.craton_cells,
+        rift_edges=req.rift_edges,
+        num_plates=req.num_plates,
+        seed=req.seed,
+    )
+
+    with _session_lock:
+        _session['active']       = True
+        _session['cells']        = cells
+        _session['plates']       = plates
+        _session['grid']         = grid
+        _session['current_time'] = 0.0
+        _session['co2_ppm']      = req.co2_ppm
+        _session['timestep_ma']  = req.timestep_ma
+        _session['last_rift_ma'] = 0.0
+
+    snapshot = sim_runner.build_snapshot(cells, grid, req.co2_ppm, 0.0, [])
+    return JSONResponse(content=snapshot)
+
+
+@app.post('/api/sim/step')
+async def sim_step(req: SimStepRequest):
+    """Advance simulation by N timesteps."""
+    with _session_lock:
+        if not _session['active']:
+            raise HTTPException(status_code=400, detail='No active session. Call /api/sim/init first.')
+        cells      = _session['cells']
+        plates     = _session['plates']
+        grid       = _session['grid']
+        co2_ppm    = _session['co2_ppm']
+        dt         = _session['timestep_ma']
+        t          = _session['current_time']
+        last_rift  = _session['last_rift_ma']
+
+    boundaries = []
+    for _ in range(req.steps):
+        boundaries, last_rift = sim_runner.step_once(
+            cells, plates, grid, dt, t, last_rift)
+        t += dt
+
+    with _session_lock:
+        _session['current_time'] = t
+        _session['last_rift_ma'] = last_rift
+
+    snapshot = sim_runner.build_snapshot(cells, grid, co2_ppm, t, boundaries)
+    return JSONResponse(content=snapshot)
+
+
+@app.post('/api/sim/reset')
+async def sim_reset():
+    """Clear the active session."""
+    with _session_lock:
+        _session['active'] = False
+        _session['cells']  = None
+        _session['plates'] = None
+        _session['grid']   = None
+    return {'ok': True}
 
 
 # ============================================================================

--- a/src/server/sim_runner.py
+++ b/src/server/sim_runner.py
@@ -17,7 +17,7 @@ import os
 import math
 import random
 import numpy as np
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(_SCRIPT_DIR, '..', 'grid'))
@@ -108,7 +108,7 @@ def initialize_cells(
 
     # --- Rift cells: split into new plate at t=0 ---
     if rift_cells:
-        rift_plate_id = num_plates + 1
+        rift_plate_id = min(num_plates + 1, 255)
         for rc in rift_cells:
             plate_id_arr[rc] = rift_plate_id
 
@@ -197,7 +197,7 @@ def run_simulation(
         _compute_velocities(cells, plates, verts, N)
 
         # --- 2. Detect and handle boundaries ---
-        _handle_boundaries_with_output(cells, adj, N, timestep_ma)
+        _handle_boundaries_with_output(cells, adj, N, timestep_ma, verts)
         # (boundary list discarded in bulk mode)
 
         # --- 3. Update ocean crust age + Parsons & Sclater depth ---
@@ -265,7 +265,7 @@ def _compute_velocities(cells, plates, verts, N):
         vel_z[idxs] = vz.astype(np.float32)
 
 
-def _handle_boundaries_with_output(cells, adj, N, dt):
+def _handle_boundaries_with_output(cells, adj, N, dt, verts):
     """
     Detect boundary types, apply geological effects, AND return boundary list.
 
@@ -296,7 +296,8 @@ def _handle_boundaries_with_output(cells, adj, N, dt):
                 continue
 
             rel = np.array([vx[j]-vx[i], vy[j]-vy[i], vz[j]-vz[i]], dtype=np.float64)
-            sep = float(rel[0])  # simplified separation proxy
+            sep_vec = np.array([verts[j, 0]-verts[i, 0], verts[j, 1]-verts[i, 1], verts[j, 2]-verts[i, 2]], dtype=np.float64)
+            sep = float(np.dot(rel, sep_vec))  # divergence along cell separation axis
 
             if sep > 0.3:
                 # Divergent / ridge
@@ -616,15 +617,15 @@ def _compute_coastal_influence(crust, adj, N, max_hops=15):
 # Top-level entry point called by server.py
 # ============================================================================
 
-_grid_cache: Optional[GeodesicGrid] = None
+_grid_cache: dict = {}
 
 
-def get_grid(level: int = 6) -> GeodesicGrid:
-    """Return cached GeodesicGrid (singleton per level)."""
+def get_grid(level: int = 7) -> GeodesicGrid:
+    """Return cached GeodesicGrid (keyed by level; 7 = 163,842 cells for production)."""
     global _grid_cache
-    if _grid_cache is None or _grid_cache.cell_count != 10 * (4 ** level) + 2:
-        _grid_cache = GeodesicGrid(level=level)
-    return _grid_cache
+    if level not in _grid_cache:
+        _grid_cache[level] = GeodesicGrid(level=level)
+    return _grid_cache[level]
 
 
 def simulate(
@@ -647,8 +648,9 @@ def simulate(
     """
     grid = get_grid(grid_level)
 
-    # Old endpoint passes rift_cells directly; convert to edges format
-    # Each cell becomes a self-edge so the derivation inside initialize_cells picks it up
+    # Legacy endpoint passes flat cell list; convert to edge format used by initialize_cells.
+    # Self-edges [c, c] are intentional: inside initialize_cells, rift cells are extracted
+    # as {c for edge in rift_edges for c in edge}, so [c, c] correctly yields {c}.
     rift_edges_compat = [[c, c] for c in rift_cells] if rift_cells else []
     cells, plates = initialize_cells(
         grid, continental_cells, craton_cells, rift_edges_compat, num_plates, seed)
@@ -688,7 +690,7 @@ def step_once(cells, plates, grid, dt, current_time, last_rift_ma):
     N     = grid.cell_count
 
     _compute_velocities(cells, plates, verts, N)
-    boundaries = _handle_boundaries_with_output(cells, adj, N, dt)
+    boundaries = _handle_boundaries_with_output(cells, adj, N, dt, verts)
     _update_ocean_crust(cells, dt)
     _apply_erosion(cells, dt)
 

--- a/src/server/sim_runner.py
+++ b/src/server/sim_runner.py
@@ -197,7 +197,8 @@ def run_simulation(
         _compute_velocities(cells, plates, verts, N)
 
         # --- 2. Detect and handle boundaries ---
-        _handle_boundaries(cells, adj, N, timestep_ma)
+        _handle_boundaries_with_output(cells, adj, N, timestep_ma)
+        # (boundary list discarded in bulk mode)
 
         # --- 3. Update ocean crust age + Parsons & Sclater depth ---
         _update_ocean_crust(cells, timestep_ma)
@@ -262,6 +263,78 @@ def _compute_velocities(cells, plates, verts, N):
         vel_x[idxs] = vx.astype(np.float32)
         vel_y[idxs] = vy.astype(np.float32)
         vel_z[idxs] = vz.astype(np.float32)
+
+
+def _handle_boundaries_with_output(cells, adj, N, dt):
+    """
+    Detect boundary types, apply geological effects, AND return boundary list.
+
+    Returns:
+        List of dicts: [{'type': 'ridge'|'subduction'|'collision'|'transform',
+                         'cell_a': int, 'cell_b': int}, ...]
+    """
+    plate_id  = cells['plate_id']
+    crust     = cells['crust_type']
+    elev      = cells['elevation']
+    orog_type = cells['orogeny_type']
+    orog_age  = cells['orogeny_age']
+    ocean_age = cells['ocean_age']
+    is_craton = cells['is_craton']
+    vx = cells['vel_x'];  vy = cells['vel_y'];  vz = cells['vel_z']
+
+    boundaries = []
+
+    for i in range(N):
+        pid_i = plate_id[i]
+        if pid_i == 0:
+            continue
+        for j in adj[i]:
+            if j <= i:
+                continue
+            pid_j = plate_id[j]
+            if pid_j == 0 or pid_j == pid_i:
+                continue
+
+            rel = np.array([vx[j]-vx[i], vy[j]-vy[i], vz[j]-vz[i]], dtype=np.float64)
+            sep = float(rel[0])  # simplified separation proxy
+
+            if sep > 0.3:
+                # Divergent / ridge
+                if crust[i] != CRUST_CONTINENTAL:
+                    ocean_age[i] = 0; elev[i] = 0.0
+                if crust[j] != CRUST_CONTINENTAL:
+                    ocean_age[j] = 0; elev[j] = 0.0
+                boundaries.append({'type': 'ridge', 'cell_a': int(i), 'cell_b': int(j)})
+
+            elif sep < -0.3:
+                both_cont = (crust[i] == CRUST_CONTINENTAL and
+                             crust[j] == CRUST_CONTINENTAL)
+                if both_cont:
+                    conv = abs(sep)
+                    if conv > 1.5:
+                        otype = OROGENY_HIGH;   h = 4000.0 + conv * 200
+                    elif conv > 0.8:
+                        otype = OROGENY_MEDIUM; h = 2500.0 + conv * 150
+                    else:
+                        otype = OROGENY_LOW;    h = 1200.0 + conv * 100
+                    for cell in (i, j):
+                        if not is_craton[cell]:
+                            elev[cell] = max(elev[cell], h)
+                            orog_type[cell] = otype; orog_age[cell] = 0
+                        else:
+                            elev[cell] = max(elev[cell], h * 0.4)
+                    boundaries.append({'type': 'collision', 'cell_a': int(i), 'cell_b': int(j)})
+                else:
+                    subduct = j if crust[i] == CRUST_CONTINENTAL else i
+                    overrid = i if crust[i] == CRUST_CONTINENTAL else j
+                    elev[subduct] = min(elev[subduct], -6000.0)
+                    elev[overrid] = max(elev[overrid], 2000.0)
+                    orog_type[overrid] = OROGENY_ANDEAN; orog_age[overrid] = 0
+                    boundaries.append({'type': 'subduction', 'cell_a': int(i), 'cell_b': int(j)})
+            else:
+                boundaries.append({'type': 'transform', 'cell_a': int(i), 'cell_b': int(j)})
+
+    return boundaries
 
 
 def _handle_boundaries(cells, adj, N, dt):
@@ -387,6 +460,126 @@ def _apply_erosion(cells, dt):
     cells['elevation'][active] = np.maximum(cells['elevation'][active], 200.0)
     new_age = cells['orogeny_age'][active].astype(np.int32) + int(dt)
     cells['orogeny_age'][active] = np.clip(new_age, 0, 65535).astype(np.uint16)
+
+
+# ============================================================================
+# Wilson Cycle mechanics
+# ============================================================================
+
+def _compute_assembly_index(cells, grid):
+    """
+    Returns (assembly_index, largest_component_cell_list).
+    assembly_index = fraction of continental cells in largest connected cluster (0-1).
+    """
+    adj   = grid._adjacency
+    crust = cells['crust_type']
+    cont  = [i for i in range(grid.cell_count) if crust[i] == CRUST_CONTINENTAL]
+    if not cont:
+        return 0.0, []
+
+    visited = set()
+    best    = []
+    for start in cont:
+        if start in visited:
+            continue
+        component = []
+        queue = [start]
+        visited.add(start)
+        while queue:
+            cur = queue.pop()
+            component.append(cur)
+            for nb in adj[cur]:
+                if nb not in visited and crust[nb] == CRUST_CONTINENTAL:
+                    visited.add(nb)
+                    queue.append(nb)
+        if len(component) > len(best):
+            best = component
+
+    return len(best) / len(cont), best
+
+
+def _find_rift_path(cluster, cells, grid, seed):
+    """
+    Find a belt of cells through the interior of the cluster for a new rift.
+    Returns a list of up to 30 cell indices forming the rift path.
+    """
+    if not cluster:
+        return []
+
+    verts     = grid._vertices
+    adj       = grid._adjacency
+    is_craton = cells['is_craton']
+    cluster_set = set(cluster)
+
+    # Cluster centroid
+    cx = float(np.mean(verts[cluster, 0]))
+    cy = float(np.mean(verts[cluster, 1]))
+    cz = float(np.mean(verts[cluster, 2]))
+    norm = math.sqrt(cx*cx + cy*cy + cz*cz) or 1.0
+    cx /= norm; cy /= norm; cz /= norm
+
+    # Non-craton interior cells sorted by proximity to centroid
+    interior = [c for c in cluster if not is_craton[c]]
+    if not interior:
+        interior = list(cluster)
+
+    interior.sort(key=lambda c: (
+        (verts[c, 0]-cx)**2 + (verts[c, 1]-cy)**2 + (verts[c, 2]-cz)**2))
+    seed_cell = interior[0]
+
+    # BFS walk up to 30 cells, staying in non-craton continental
+    rng = random.Random(seed)
+    visited = {seed_cell}
+    path    = [seed_cell]
+    frontier = [seed_cell]
+    for _ in range(29):
+        candidates = []
+        for c in frontier:
+            for nb in adj[c]:
+                if nb not in visited and nb in cluster_set and not is_craton[nb]:
+                    candidates.append(nb)
+        if not candidates:
+            break
+        next_cell = rng.choice(candidates)
+        visited.add(next_cell)
+        path.append(next_cell)
+        frontier = [next_cell]
+
+    return path
+
+
+def _maybe_trigger_auto_rift(cells, plates, grid, current_time, last_rift_ma, seed):
+    """
+    If supercontinent assembled for >200 Ma, inject a new rift. Returns new last_rift_ma.
+    """
+    assembly, cluster = _compute_assembly_index(cells, grid)
+    if assembly < 0.70:
+        return last_rift_ma  # not yet a supercontinent
+    if current_time - last_rift_ma < 200.0:
+        return last_rift_ma  # still in dwell period
+
+    rift_cells = _find_rift_path(cluster, cells, grid, seed)
+    if not rift_cells:
+        return last_rift_ma
+
+    new_plate_id = max((p['id'] for p in plates), default=0) + 1
+    rng = random.Random(seed)
+    new_euler_lat = rng.uniform(-60, 60)
+    new_euler_lon = rng.uniform(-180, 180)
+
+    for rc in rift_cells:
+        cells['plate_id'][rc] = new_plate_id
+        cells['elevation'][rc] = max(float(cells['elevation'][rc]) - 500.0, -200.0)
+
+    plates.append({
+        'id':         new_plate_id,
+        'euler_lat':  new_euler_lat,
+        'euler_lon':  new_euler_lon,
+        'euler_rate': rng.uniform(2.0, 5.0),
+        'cells':      rift_cells,
+    })
+
+    return current_time
 
 
 # ============================================================================
@@ -583,14 +776,13 @@ def step_once(cells, plates, grid, dt, current_time, last_rift_ma):
     N     = grid.cell_count
 
     _compute_velocities(cells, plates, verts, N)
-    # Use existing _handle_boundaries (returns nothing; boundaries added in Task 3)
-    _handle_boundaries(cells, adj, N, dt)
-    boundaries = []  # Task 3 will populate this
+    boundaries = _handle_boundaries_with_output(cells, adj, N, dt)
     _update_ocean_crust(cells, dt)
     _apply_erosion(cells, dt)
 
-    # Wilson Cycle placeholder (Task 3 will implement this)
-    new_last_rift = last_rift_ma
+    new_last_rift = _maybe_trigger_auto_rift(
+        cells, plates, grid, current_time, last_rift_ma,
+        seed=int(current_time * 13) % (2**31))
 
     return boundaries, new_last_rift
 

--- a/src/server/sim_runner.py
+++ b/src/server/sim_runner.py
@@ -337,97 +337,6 @@ def _handle_boundaries_with_output(cells, adj, N, dt):
     return boundaries
 
 
-def _handle_boundaries(cells, adj, N, dt):
-    """Detect boundary types and apply geological effects."""
-    plate_id  = cells['plate_id']
-    crust     = cells['crust_type']
-    elev      = cells['elevation']
-    orog_type = cells['orogeny_type']
-    orog_age  = cells['orogeny_age']
-    ocean_age = cells['ocean_age']
-    is_craton = cells['is_craton']
-    vx = cells['vel_x']
-    vy = cells['vel_y']
-    vz = cells['vel_z']
-
-    for i in range(N):
-        pid_i = plate_id[i]
-        if pid_i == 0:
-            continue
-        vi = np.array([vx[i], vy[i], vz[i]], dtype=np.float64)
-
-        for j in adj[i]:
-            if j <= i:
-                continue
-            pid_j = plate_id[j]
-            if pid_j == 0 or pid_j == pid_i:
-                continue
-
-            # Relative velocity j relative to i
-            rel = np.array([vx[j]-vx[i], vy[j]-vy[i], vz[j]-vz[i]], dtype=np.float64)
-            # Direction i → j (chord on unit sphere)
-            # Not stored pre-computed; just use vertex difference
-
-            sep = rel[0]*(j > i) + rel[1]*0.1  # simplified separation scalar
-            # Better: use dot with position difference
-            # (approximate: if both vels point away → divergent)
-            # Simplified: use magnitude of rel vel component
-            # Use sum of projection of velocities along i->j as separator
-
-            # Actually, compute proper separation rate
-            # rel_vel = vj - vi; dir = normalize(pos_j - pos_i)
-            # sep = dot(rel_vel, dir)
-            # (skipping for performance — use plate-level relative angle instead)
-
-            # Simplified boundary classification based on plate IDs:
-            # This gives a visually plausible result without full vector math per pair
-            sep = float(rel[0])  # rough approximation
-
-            # Classify boundary
-            if sep > 0.3:      # divergent
-                # New oceanic crust at boundary
-                if crust[i] != CRUST_CONTINENTAL:
-                    ocean_age[i] = 0
-                    elev[i] = 0.0
-                if crust[j] != CRUST_CONTINENTAL:
-                    ocean_age[j] = 0
-                    elev[j] = 0.0
-
-            elif sep < -0.3:   # convergent
-                both_cont = (crust[i] == CRUST_CONTINENTAL and
-                             crust[j] == CRUST_CONTINENTAL)
-                if both_cont:
-                    # Continental collision → orogeny
-                    conv = abs(sep)
-                    if conv > 1.5:
-                        otype = OROGENY_HIGH
-                        h = 4000.0 + conv * 200
-                    elif conv > 0.8:
-                        otype = OROGENY_MEDIUM
-                        h = 2500.0 + conv * 150
-                    else:
-                        otype = OROGENY_LOW
-                        h = 1200.0 + conv * 100
-
-                    for cell in (i, j):
-                        if not is_craton[cell]:
-                            elev[cell] = max(elev[cell], h)
-                            orog_type[cell] = otype
-                            orog_age[cell] = 0
-                        else:
-                            # Cratons don't build mountains as high
-                            elev[cell] = max(elev[cell], h * 0.4)
-                else:
-                    # Subduction
-                    subduct_cell = j if crust[i] == CRUST_CONTINENTAL else i
-                    elev[subduct_cell] = min(elev[subduct_cell], -6000.0)
-                    # Volcanic arc on overriding plate (next neighbour)
-                    overriding = i if crust[i] == CRUST_CONTINENTAL else j
-                    elev[overriding] = max(elev[overriding], 2000.0)
-                    orog_type[overriding] = OROGENY_ANDEAN
-                    orog_age[overriding] = 0
-
-
 def _update_ocean_crust(cells, dt):
     """Age oceanic cells; apply Parsons & Sclater depth equation."""
     ocean_mask = (cells['crust_type'] == CRUST_OCEANIC)
@@ -562,7 +471,10 @@ def _maybe_trigger_auto_rift(cells, plates, grid, current_time, last_rift_ma, se
     if not rift_cells:
         return last_rift_ma
 
-    new_plate_id = max((p['id'] for p in plates), default=0) + 1
+    existing_max = max((p['id'] for p in plates), default=0)
+    new_plate_id = min(existing_max + 1, 255)
+    if new_plate_id in {p['id'] for p in plates}:
+        return last_rift_ma  # no available plate ID slots
     rng = random.Random(seed)
     new_euler_lat = rng.uniform(-60, 60)
     new_euler_lon = rng.uniform(-180, 180)
@@ -782,7 +694,7 @@ def step_once(cells, plates, grid, dt, current_time, last_rift_ma):
 
     new_last_rift = _maybe_trigger_auto_rift(
         cells, plates, grid, current_time, last_rift_ma,
-        seed=int(current_time * 13) % (2**31))
+        seed=int(round(current_time)) % (2**31))
 
     return boundaries, new_last_rift
 

--- a/src/server/sim_runner.py
+++ b/src/server/sim_runner.py
@@ -46,7 +46,7 @@ def initialize_cells(
     grid: GeodesicGrid,
     continental_cells: List[int],
     craton_cells: List[int],
-    rift_cells: List[int],
+    rift_edges: List[List[int]],
     num_plates: int,
     seed: int,
 ) -> tuple:
@@ -58,7 +58,13 @@ def initialize_cells(
         orogeny_age, orogeny_type, is_craton
 
     plates_list: list of dicts with euler_lat/lon/rate and cell index lists
+
+    rift_edges: list of [cell_a, cell_b] pairs defining rift lines.
+    Rift cells are derived as all cells that appear in any rift edge.
     """
+    # Derive rift_cells from edges (all cells that touch a rift edge)
+    rift_cells = list({c for edge in rift_edges for c in edge})
+
     rng = random.Random(seed)
     N = grid.cell_count
     verts = grid._vertices  # (N, 3) float64
@@ -536,8 +542,11 @@ def simulate(
     """
     grid = get_grid(grid_level)
 
+    # Old endpoint passes rift_cells directly; convert to edges format
+    # Each cell becomes a self-edge so the derivation inside initialize_cells picks it up
+    rift_edges_compat = [[c, c] for c in rift_cells] if rift_cells else []
     cells, plates = initialize_cells(
-        grid, continental_cells, craton_cells, rift_cells, num_plates, seed)
+        grid, continental_cells, craton_cells, rift_edges_compat, num_plates, seed)
 
     cells = run_simulation(
         grid, cells, plates,
@@ -558,4 +567,46 @@ def simulate(
         'temperature':   climate['temperature'].tolist(),
         'precipitation': climate['precipitation'].tolist(),
         'koppen':        climate['koppen'].tolist(),
+    }
+
+
+# ============================================================================
+# Step-by-step simulation API helpers
+# ============================================================================
+
+def step_once(cells, plates, grid, dt, current_time, last_rift_ma):
+    """
+    Advance simulation by one timestep. Returns (boundaries, new_last_rift_ma).
+    """
+    verts = grid._vertices
+    adj   = grid._adjacency
+    N     = grid.cell_count
+
+    _compute_velocities(cells, plates, verts, N)
+    # Use existing _handle_boundaries (returns nothing; boundaries added in Task 3)
+    _handle_boundaries(cells, adj, N, dt)
+    boundaries = []  # Task 3 will populate this
+    _update_ocean_crust(cells, dt)
+    _apply_erosion(cells, dt)
+
+    # Wilson Cycle placeholder (Task 3 will implement this)
+    new_last_rift = last_rift_ma
+
+    return boundaries, new_last_rift
+
+
+def build_snapshot(cells, grid, co2_ppm, current_time_ma, boundaries):
+    """Build JSON-serialisable snapshot dict for the frontend."""
+    climate = derive_climate(grid, cells, co2_ppm=co2_ppm)
+    return {
+        'current_time_ma': current_time_ma,
+        'cell_count':      grid.cell_count,
+        'elevation':       cells['elevation'].tolist(),
+        'crust_type':      cells['crust_type'].tolist(),
+        'plate_id':        cells['plate_id'].tolist(),
+        'orogeny_type':    cells['orogeny_type'].tolist(),
+        'temperature':     climate['temperature'].tolist(),
+        'precipitation':   climate['precipitation'].tolist(),
+        'koppen':          climate['koppen'].tolist(),
+        'boundaries':      boundaries,
     }

--- a/src/web/api.js
+++ b/src/web/api.js
@@ -81,7 +81,7 @@ const API = {
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify(params),
         });
-        if (!r.ok) throw new Error((await r.json()).detail || r.statusText);
+        if (!r.ok) throw new Error((await r.json().catch(() => ({}))).detail || r.statusText);
         return r.json();
     },
 
@@ -97,12 +97,13 @@ const API = {
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({ steps }),
         });
-        if (!r.ok) throw new Error((await r.json()).detail || r.statusText);
+        if (!r.ok) throw new Error((await r.json().catch(() => ({}))).detail || r.statusText);
         return r.json();
     },
 
     /** Clear the active step-by-step session. */
     async simReset() {
-        await fetch('/api/sim/reset', { method: 'POST' });
+        const r = await fetch('/api/sim/reset', { method: 'POST' });
+        if (!r.ok) throw new Error(`Reset failed: ${r.status}`);
     },
 };

--- a/src/web/api.js
+++ b/src/web/api.js
@@ -59,4 +59,50 @@ const API = {
         if (!res.ok) return null;
         return res.json();
     },
+
+    /**
+     * Initialise a step-by-step simulation session.
+     *
+     * @param {object} params
+     *   continental_cells  int[]        cell indices painted continental
+     *   craton_cells       int[]        cell indices marked as cratons
+     *   rift_edges         int[][]      pairs [[cell_a, cell_b], ...] forming rift lines
+     *   seed               int          RNG seed
+     *   co2_ppm            float        atmospheric CO2 (ppm)
+     *   num_plates         int          number of tectonic plates
+     *   grid_level         int          geodesic grid subdivision level
+     *   timestep_ma        float        Ma per step
+     *
+     * @returns Promise<Snapshot>  initial state at t=0
+     */
+    async simInit(params) {
+        const r = await fetch('/api/sim/init', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(params),
+        });
+        if (!r.ok) throw new Error((await r.json()).detail || r.statusText);
+        return r.json();
+    },
+
+    /**
+     * Advance the active session by N timesteps.
+     *
+     * @param {number} steps  number of timesteps to advance (default 1)
+     * @returns Promise<Snapshot>  state after advancing
+     */
+    async simStep(steps = 1) {
+        const r = await fetch('/api/sim/step', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ steps }),
+        });
+        if (!r.ok) throw new Error((await r.json()).detail || r.statusText);
+        return r.json();
+    },
+
+    /** Clear the active step-by-step session. */
+    async simReset() {
+        await fetch('/api/sim/reset', { method: 'POST' });
+    },
 };

--- a/src/web/globe.js
+++ b/src/web/globe.js
@@ -160,9 +160,21 @@ class GeodesicGlobe {
         // Wireframe visibility
         this._wireVisible = false;
 
+        // Rift edges: Set of 'minIdx_maxIdx' strings; rendered as red lines
+        this._riftEdges    = new Set();
+        this._riftLineMesh = null;    // THREE.LineSegments (red)
+        this._hoverLineMesh = null;   // THREE.LineSegments (yellow highlight)
+        this._hoveredEdge  = null;    // {cell_a, cell_b} | null
+
+        // Edge-by-cell lookup: cellIdx → [{cell_a, cell_b}, ...]
+        this._edgesByCell  = null;
+
         // Callbacks
         this.onCellHover = null;  // (cellIdx, lat, lon) => void
         this.onPaintChanged = null; // () => void
+        this.onContiguityError = null; // (msg: string) => void
+
+        this._errorTimer = null;
 
         this._init();
     }
@@ -286,6 +298,107 @@ class GeodesicGlobe {
         // Store face→cell mapping for fast picking
         // For face f, the 3 vertices are cells a,b,c
         this._faceCells = faces;  // direct reference
+
+        // --- Edge-by-cell lookup (for rift edge picking) ---
+        this._edgesByCell = new Array(N).fill(null).map(() => []);
+        if (grid.edges) {
+            for (const [a, b] of grid.edges) {
+                this._edgesByCell[a].push({ cell_a: a, cell_b: b });
+                this._edgesByCell[b].push({ cell_a: a, cell_b: b });
+            }
+        }
+
+        // --- Rift edge LineSegments (initially empty, red) ---
+        const riftGeo = new THREE.BufferGeometry();
+        riftGeo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(0), 3));
+        const riftMat = new THREE.LineBasicMaterial({ color: 0xff2200 });
+        this._riftLineMesh = new THREE.LineSegments(riftGeo, riftMat);
+        this._scene.add(this._riftLineMesh);
+
+        // --- Hover edge highlight (single line, yellow) ---
+        const hoverPos = new Float32Array(6);
+        const hoverGeo = new THREE.BufferGeometry();
+        hoverGeo.setAttribute('position', new THREE.BufferAttribute(hoverPos, 3));
+        const hoverMat = new THREE.LineBasicMaterial({ color: 0xffee00 });
+        this._hoverLineMesh = new THREE.LineSegments(hoverGeo, hoverMat);
+        this._hoverLineMesh.visible = false;
+        this._scene.add(this._hoverLineMesh);
+    }
+
+    // ── Rift edge helpers ────────────────────────────────────────────────────
+
+    _refreshRiftLines() {
+        if (!this._riftLineMesh || !this._grid) return;
+        const verts = this._grid.vertices;
+        const SCALE = 1.003;
+
+        const pts = new Float32Array(this._riftEdges.size * 6);
+        let i = 0;
+        for (const key of this._riftEdges) {
+            const [a, b] = key.split('_').map(Number);
+            const va = verts[a], vb = verts[b];
+            pts[i++] = va[0]*SCALE; pts[i++] = va[1]*SCALE; pts[i++] = va[2]*SCALE;
+            pts[i++] = vb[0]*SCALE; pts[i++] = vb[1]*SCALE; pts[i++] = vb[2]*SCALE;
+        }
+
+        this._riftLineMesh.geometry.setAttribute(
+            'position', new THREE.BufferAttribute(pts, 3));
+        this._riftLineMesh.geometry.attributes.position.needsUpdate = true;
+        this._riftLineMesh.geometry.setDrawRange(0, this._riftEdges.size * 2);
+    }
+
+    _pickEdge(event) {
+        if (!this._edgesByCell || !this._mesh) return null;
+
+        // Step 1: find hovered cell
+        const cellIdx = this._pickCell(event);
+        if (cellIdx < 0) return null;
+
+        // Step 2: gather edges of this cell and its immediate neighbors
+        const candidates = [...(this._edgesByCell[cellIdx] || [])];
+        for (const nb of this._grid.adjacency[cellIdx]) {
+            for (const edge of (this._edgesByCell[nb] || [])) {
+                candidates.push(edge);
+            }
+        }
+        if (!candidates.length) return null;
+
+        // Step 3: cast ray and find closest edge midpoint
+        const rect = this._renderer.domElement.getBoundingClientRect();
+        const mx   = ((event.clientX - rect.left) / rect.width)  * 2 - 1;
+        const my   = -((event.clientY - rect.top)  / rect.height) * 2 + 1;
+        this._raycaster.setFromCamera(new THREE.Vector2(mx, my), this._camera);
+        const ray = this._raycaster.ray;
+
+        const verts = this._grid.vertices;
+        let bestEdge = null, bestDist = Infinity;
+
+        for (const { cell_a, cell_b } of candidates) {
+            const va = verts[cell_a], vb = verts[cell_b];
+            const mid = new THREE.Vector3(
+                (va[0]+vb[0])/2, (va[1]+vb[1])/2, (va[2]+vb[2])/2);
+            const d = ray.distanceToPoint(mid);
+            if (d < bestDist) { bestDist = d; bestEdge = { cell_a, cell_b }; }
+        }
+
+        return bestDist < 0.04 ? bestEdge : null;
+    }
+
+    _toggleRiftEdge({ cell_a, cell_b }) {
+        const a = Math.min(cell_a, cell_b);
+        const b = Math.max(cell_a, cell_b);
+        const key = `${a}_${b}`;
+        if (this._riftEdges.has(key)) {
+            this._riftEdges.delete(key);
+        } else {
+            this._riftEdges.add(key);
+        }
+        this._refreshRiftLines();
+        if (this.onPaintChanged) this.onPaintChanged();
+    }
+
+    getRiftEdges() {
+        return Array.from(this._riftEdges).map(k => k.split('_').map(Number));
     }
 
     // ── Colour refresh ───────────────────────────────────────────────────────
@@ -337,12 +450,71 @@ class GeodesicGlobe {
         buf.needsUpdate = true;
     }
 
+    // ── Contiguity helpers ────────────────────────────────────────────────────
+
+    _hasContinentalCells() {
+        if (!this._paintState) return false;
+        for (let i = 0; i < this._N; i++) {
+            if (this._paintState[i] === 1 || this._paintState[i] === 2) return true;
+        }
+        return false;
+    }
+
+    _isAdjacentToContinent(cellIdx) {
+        if (!this._paintState || !this._grid) return false;
+        // The cell itself counts as adjacent (allows re-painting)
+        if (this._paintState[cellIdx] === 1 || this._paintState[cellIdx] === 2) return true;
+        // Any neighbor that is continental/craton counts
+        for (const nb of this._grid.adjacency[cellIdx]) {
+            if (this._paintState[nb] === 1 || this._paintState[nb] === 2) return true;
+        }
+        return false;
+    }
+
+    _countCratonRegions() {
+        if (!this._paintState) return 0;
+        const visited = new Set();
+        let regions = 0;
+        for (let start = 0; start < this._N; start++) {
+            if (this._paintState[start] !== 2) continue;
+            if (visited.has(start)) continue;
+            regions++;
+            const q = [start];
+            visited.add(start);
+            while (q.length) {
+                const cur = q.pop();
+                for (const nb of this._grid.adjacency[cur]) {
+                    if (!visited.has(nb) && this._paintState[nb] === 2) {
+                        visited.add(nb);
+                        q.push(nb);
+                    }
+                }
+            }
+        }
+        return regions;
+    }
+
     // ── Cell painting ────────────────────────────────────────────────────────
 
     paintCell(cellIdx, toolType) {
         if (!this._paintState || cellIdx < 0 || cellIdx >= this._N) return;
+        if (toolType === 'rift') return;  // rift is edge-based, not cell-based
 
-        const typeMap = { ocean: 0, continental: 1, craton: 2, rift: 3 };
+        // Contiguity enforcement: new continental/craton cells must be adjacent to existing land
+        if ((toolType === 'continental' || toolType === 'craton') && this._hasContinentalCells()) {
+            // Check all cells in the brush radius — reject if none is adjacent
+            const affected = this._getCellsInRadius(cellIdx, this._brushRadius);
+            const anyAdjacent = affected.some(idx => this._isAdjacentToContinent(idx));
+            if (!anyAdjacent) {
+                if (this.onContiguityError) {
+                    this.onContiguityError(
+                        'Continental cells must be contiguous — paint adjacent to existing land.');
+                }
+                return;
+            }
+        }
+
+        const typeMap = { ocean: 0, continental: 1, craton: 2 };
         const typeVal = typeMap[toolType] ?? 1;
 
         // Paint with brush radius
@@ -430,9 +602,11 @@ class GeodesicGlobe {
     // ── Getters ───────────────────────────────────────────────────────────────
 
     getPaintedCells(type) {
+        if (type === 'rift') return [];  // rift is now edge-based; use getRiftEdges()
         if (!this._paintState) return [];
-        const typeMap = { ocean: 0, continental: 1, craton: 2, rift: 3 };
+        const typeMap = { ocean: 0, continental: 1, craton: 2 };
         const v = typeMap[type];
+        if (v === undefined) return [];
         const result = [];
         for (let i = 0; i < this._N; i++) {
             if (this._paintState[i] === v) result.push(i);
@@ -441,16 +615,20 @@ class GeodesicGlobe {
     }
 
     getPaintStats() {
-        if (!this._paintState) return { ocean: 0, continental: 0, craton: 0, rift: 0 };
-        let ocean=0, cont=0, craton=0, rift=0;
+        if (!this._paintState) return { ocean: 0, continental: 0, craton: 0, craton_regions: 0, rift: 0, total: 0 };
+        let ocean=0, cont=0, craton=0;
         for (let i = 0; i < this._N; i++) {
             const v = this._paintState[i];
             if (v===0) ocean++;
             else if (v===1) cont++;
             else if (v===2) craton++;
-            else if (v===3) rift++;
         }
-        return { ocean, continental: cont, craton, rift, total: this._N };
+        return {
+            ocean, continental: cont, craton,
+            craton_regions: this._countCratonRegions(),
+            rift: this._riftEdges ? this._riftEdges.size : 0,
+            total: this._N
+        };
     }
 
     getBrushRadius()  { return this._brushRadius; }
@@ -512,6 +690,24 @@ class GeodesicGlobe {
                 this.paintCell(cellIdx, this._tool);
             }
         }
+
+        // Rift edge hover highlight
+        if (this._tool === 'rift') {
+            const edge = this._pickEdge(e);
+            this._hoveredEdge = edge;
+            if (edge && this._hoverLineMesh) {
+                const verts = this._grid.vertices;
+                const SCALE = 1.003;
+                const va = verts[edge.cell_a], vb = verts[edge.cell_b];
+                const pos = this._hoverLineMesh.geometry.attributes.position;
+                pos.array[0] = va[0]*SCALE; pos.array[1] = va[1]*SCALE; pos.array[2] = va[2]*SCALE;
+                pos.array[3] = vb[0]*SCALE; pos.array[4] = vb[1]*SCALE; pos.array[5] = vb[2]*SCALE;
+                pos.needsUpdate = true;
+                this._hoverLineMesh.visible = true;
+            } else if (this._hoverLineMesh) {
+                this._hoverLineMesh.visible = false;
+            }
+        }
     }
 
     _onMouseDown(e) {
@@ -519,6 +715,13 @@ class GeodesicGlobe {
         e.preventDefault();
         this._mouseDown = true;
         this._lastPainted = -1;
+
+        if (this._tool === 'rift') {
+            const edge = this._pickEdge(e);
+            if (edge) this._toggleRiftEdge(edge);
+            return;
+        }
+
         const cellIdx = this._pickCell(e);
         if (cellIdx >= 0) {
             this._lastPainted = cellIdx;

--- a/src/web/globe.js
+++ b/src/web/globe.js
@@ -164,6 +164,7 @@ class GeodesicGlobe {
         this._riftEdges    = new Set();
         this._riftLineMesh = null;    // THREE.LineSegments (red)
         this._hoverLineMesh = null;   // THREE.LineSegments (yellow highlight)
+        this._boundaryMesh = null;
         this._hoveredEdge  = null;    // {cell_a, cell_b} | null
 
         // Edge-by-cell lookup: cellIdx → [{cell_a, cell_b}, ...]
@@ -325,6 +326,15 @@ class GeodesicGlobe {
         this._hoverLineMesh = new THREE.LineSegments(hoverGeo, hoverMat);
         this._hoverLineMesh.visible = false;
         this._scene.add(this._hoverLineMesh);
+
+        // --- Boundary lines (updated each simulation step) ---
+        const bndGeo = new THREE.BufferGeometry();
+        bndGeo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(0), 3));
+        bndGeo.setAttribute('color',    new THREE.BufferAttribute(new Float32Array(0), 3));
+        const bndMat = new THREE.LineBasicMaterial({ vertexColors: true });
+        this._boundaryMesh = new THREE.LineSegments(bndGeo, bndMat);
+        this._boundaryMesh.visible = false;
+        this._scene.add(this._boundaryMesh);
     }
 
     // ── Rift edge helpers ────────────────────────────────────────────────────
@@ -581,7 +591,53 @@ class GeodesicGlobe {
                 }
             }
         }
+        if (result.boundaries) this.applyBoundaries(result.boundaries);  // NEW
         this._refreshColors();
+    }
+
+    applyBoundaries(boundaries) {
+        if (!this._boundaryMesh || !this._grid) return;
+        if (!boundaries || !boundaries.length) {
+            this._boundaryMesh.geometry.setDrawRange(0, 0);
+            return;
+        }
+
+        const SCALE = 1.005;  // lift slightly above sphere surface
+        const verts = this._grid.vertices;
+
+        const TYPE_COLORS = {
+            ridge:      [1.0, 0.6, 0.0],   // orange
+            subduction: [0.8, 0.1, 0.1],   // red
+            transform:  [0.9, 0.85, 0.0],  // yellow
+            collision:  [1.0, 0.5, 0.65],  // pink
+        };
+
+        const nLines = boundaries.length;
+        const pos = new Float32Array(nLines * 6);
+        const col = new Float32Array(nLines * 6);
+
+        for (let i = 0; i < nLines; i++) {
+            const { type, cell_a, cell_b } = boundaries[i];
+            const va = verts[cell_a], vb = verts[cell_b];
+            const c  = TYPE_COLORS[type] || [0.6, 0.6, 0.6];
+            const k  = i * 6;
+            pos[k]   = va[0]*SCALE; pos[k+1] = va[1]*SCALE; pos[k+2] = va[2]*SCALE;
+            pos[k+3] = vb[0]*SCALE; pos[k+4] = vb[1]*SCALE; pos[k+5] = vb[2]*SCALE;
+            col[k]   = c[0]; col[k+1] = c[1]; col[k+2] = c[2];
+            col[k+3] = c[0]; col[k+4] = c[1]; col[k+5] = c[2];
+        }
+
+        this._boundaryMesh.geometry.setAttribute(
+            'position', new THREE.BufferAttribute(pos, 3));
+        this._boundaryMesh.geometry.setAttribute(
+            'color', new THREE.BufferAttribute(col, 3));
+        this._boundaryMesh.geometry.setDrawRange(0, nLines * 2);
+        this._boundaryMesh.geometry.attributes.position.needsUpdate = true;
+        this._boundaryMesh.geometry.attributes.color.needsUpdate = true;
+    }
+
+    toggleBoundaries(visible) {
+        if (this._boundaryMesh) this._boundaryMesh.visible = visible;
     }
 
     // ── Mode / tool setters ──────────────────────────────────────────────────

--- a/src/web/globe.js
+++ b/src/web/globe.js
@@ -174,7 +174,9 @@ class GeodesicGlobe {
         this.onPaintChanged = null; // () => void
         this.onContiguityError = null; // (msg: string) => void
 
-        this._errorTimer = null;
+        // Craton region cache (dirty flag + cached count)
+        this._cratonRegionsDirty = true;
+        this._cratonRegionsCache = 0;
 
         this._init();
     }
@@ -381,7 +383,9 @@ class GeodesicGlobe {
             if (d < bestDist) { bestDist = d; bestEdge = { cell_a, cell_b }; }
         }
 
-        return bestDist < 0.04 ? bestEdge : null;
+        const camDist = this._camera ? this._camera.position.length() : 2.5;
+        const threshold = 0.04 * (camDist / 2.5);
+        return bestDist < threshold ? bestEdge : null;
     }
 
     _toggleRiftEdge({ cell_a, cell_b }) {
@@ -472,6 +476,7 @@ class GeodesicGlobe {
     }
 
     _countCratonRegions() {
+        if (!this._cratonRegionsDirty) return this._cratonRegionsCache;
         if (!this._paintState) return 0;
         const visited = new Set();
         let regions = 0;
@@ -491,6 +496,8 @@ class GeodesicGlobe {
                 }
             }
         }
+        this._cratonRegionsCache = regions;
+        this._cratonRegionsDirty = false;
         return regions;
     }
 
@@ -528,6 +535,7 @@ class GeodesicGlobe {
         }
 
         if (changed) {
+            this._cratonRegionsDirty = true;  // may have added/removed craton cells
             this._refreshColors();
             if (this.onPaintChanged) this.onPaintChanged();
         }
@@ -555,6 +563,7 @@ class GeodesicGlobe {
     clearPaint() {
         if (!this._paintState) return;
         this._paintState.fill(0);
+        this._cratonRegionsDirty = true;
         this._refreshColors();
         if (this.onPaintChanged) this.onPaintChanged();
     }
@@ -582,6 +591,10 @@ class GeodesicGlobe {
         const isOrbit = tool === 'orbit';
         this._controls.enabled = isOrbit;
         this._container.classList.toggle('orbit-mode', isOrbit);
+        // Hide rift hover highlight when switching away from rift tool
+        if (tool !== 'rift' && this._hoverLineMesh) {
+            this._hoverLineMesh.visible = false;
+        }
     }
 
     setColorMode(mode) {

--- a/src/web/globe.js
+++ b/src/web/globe.js
@@ -746,9 +746,7 @@ class GeodesicGlobe {
             if (this.onCellHover) {
                 const v = this._grid.vertices[cellIdx];
                 const z = Math.max(-1, Math.min(1, v[2]));
-                const lat = Math.degrees
-                    ? Math.degrees(Math.asin(z))
-                    : Math.asin(z) * (180 / Math.PI);
+                const lat = Math.asin(z) * (180 / Math.PI);
                 const lon = Math.atan2(v[1], v[0]) * (180 / Math.PI);
                 this.onCellHover(cellIdx, lat, lon);
             }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -90,38 +90,49 @@
         <div class="legend-item"><div class="legend-swatch" style="background:#c8a020"></div><span>Craton</span></div>
         <div class="legend-item"><div class="legend-swatch" style="background:#d04020"></div><span>Rift</span></div>
       </div>
+      <div style="margin-top:6px">
+        <button class="tool-btn" id="btn-boundaries" title="Toggle boundary lines (B)">
+          ⚡ Boundaries
+        </button>
+      </div>
     </div>
 
     <!-- Simulation parameters -->
     <div class="sidebar-section">
       <h2>Simulation</h2>
       <div class="param-row">
-        <label>Duration (Ma)</label>
-        <input type="number" id="param-time" value="500" min="50" max="2000" step="50">
-      </div>
-      <div class="param-row">
         <label>Num plates</label>
-        <input type="number" id="param-plates" value="7" min="3" max="15">
+        <input type="number" id="param-plates" value="7" min="3" max="20">
       </div>
       <div class="param-row">
         <label>CO₂ (ppm)</label>
         <input type="number" id="param-co2" value="400" min="100" max="4000">
       </div>
       <div class="param-row">
+        <label>Timestep (Ma)</label>
+        <input type="number" id="param-timestep" value="10" min="1" max="50">
+      </div>
+      <div class="param-row">
         <label>Seed</label>
         <input type="number" id="param-seed" value="42">
       </div>
 
-      <button class="btn" id="btn-simulate">▶ Run Simulation</button>
-      <button class="btn" id="btn-reset-view" style="margin-top:2px">⌖ Reset View</button>
+      <button class="btn" id="btn-sim-init">⚙ Initialise</button>
+    </div>
 
-      <!-- Progress -->
-      <div id="sim-progress-wrap">
-        <div class="progress-bar">
-          <div class="progress-fill" id="progress-fill"></div>
-        </div>
-        <div class="progress-text" id="progress-text">0 / 500 Ma</div>
+    <!-- Timeline (shown after init) -->
+    <div class="sidebar-section" id="timeline-section" style="display:none">
+      <h2>Timeline — <span id="tl-time">0 Ma</span></h2>
+      <div class="timeline-controls">
+        <button class="tool-btn" id="btn-step-back"  title="Step back">◀</button>
+        <button class="tool-btn" id="btn-play-pause" title="Play / Pause (P)">▶</button>
+        <button class="tool-btn" id="btn-step-fwd"   title="Step forward">▶|</button>
       </div>
+      <input type="range" id="timeline-slider" min="0" max="0" value="0"
+             style="width:100%;margin:6px 0">
+      <button class="btn" id="btn-use-state" style="margin-top:4px">
+        ✓ Use This State
+      </button>
     </div>
 
     <!-- Paint stats -->

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -137,7 +137,7 @@
       </div>
       <div class="stat-row">
         <span class="stat-label">Cratons</span>
-        <span class="stat-value" id="stat-cratons">0</span>
+        <span class="stat-value" id="stat-cratons">0 regions</span>
       </div>
       <div class="stat-row">
         <span class="stat-label">Rift cells</span>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -181,7 +181,9 @@
         <b style="color:#888">Space</b> — orbit mode<br>
         <b style="color:#888">[ ]</b> — brush size<br>
         <b style="color:#888">G</b> — toggle grid<br>
-        <b style="color:#888">1–6</b> — display mode
+        <b style="color:#888">1–6</b> — display mode<br>
+        <b style="color:#888">P</b> — play / pause<br>
+        <b style="color:#888">B</b> — toggle boundaries
       </div>
     </div>
 

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -304,3 +304,14 @@ body {
     max-width: 180px;
 }
 #tooltip.visible { display: block; }
+
+/* Timeline controls */
+.timeline-controls {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 6px;
+}
+#timeline-slider {
+    accent-color: #5588aa;
+    cursor: pointer;
+}

--- a/src/web/ui.js
+++ b/src/web/ui.js
@@ -8,14 +8,19 @@
 class GeoForgeUI {
     constructor(globe) {
         this._globe      = globe;
-        this._polling    = null;   // setInterval handle for progress polling
         this._running    = false;
-        this._errorTimer = null;
+        this._snapshots    = [];    // [{time_ma, result}, ...]
+        this._snapshotIdx  = -1;    // index of currently displayed snapshot
+        this._playing      = false;
+        this._playInterval = null;
+        this._initialized  = false;
+        this._errorTimer   = null;
     }
 
     init() {
         this._bindToolbar();
         this._bindSidebar();
+        this._bindTimeline();
         this._bindKeyboard();
         this._bindGlobeCallbacks();
         this._updateStats();
@@ -74,11 +79,6 @@ class GeoForgeUI {
                 const mode = tab.dataset.mode;
                 this._setColorMode(mode);
             });
-        });
-
-        // Simulate button
-        document.getElementById('btn-simulate')?.addEventListener('click', () => {
-            this._runSimulation();
         });
 
         // Reset view button
@@ -160,85 +160,163 @@ class GeoForgeUI {
         ).join('');
     }
 
-    // ── Simulation ────────────────────────────────────────────────────────────
+    // ── Timeline ─────────────────────────────────────────────────────────────
 
-    async _runSimulation() {
-        if (this._running) return;
+    _bindTimeline() {
+        document.getElementById('btn-sim-init')?.addEventListener('click', () => {
+            this._initSimulation();
+        });
+        document.getElementById('btn-step-fwd')?.addEventListener('click', () => {
+            this._stepForward();
+        });
+        document.getElementById('btn-step-back')?.addEventListener('click', () => {
+            this._stepBack();
+        });
+        document.getElementById('btn-play-pause')?.addEventListener('click', () => {
+            this._togglePlay();
+        });
+        document.getElementById('timeline-slider')?.addEventListener('input', e => {
+            this._stopPlay();
+            this._setSnapshotIdx(parseInt(e.target.value));
+        });
+        document.getElementById('btn-use-state')?.addEventListener('click', () => {
+            this._finaliseState();
+        });
+    }
 
+    async _initSimulation() {
         const stats = this._globe.getPaintStats();
         if (stats.continental + stats.craton === 0) {
-            alert('Paint some continental cells first (hold Continental tool and drag on the globe).');
+            alert('Paint some continental cells first.');
             return;
         }
 
-        this._running = true;
-        this._setSimRunning(true);
+        const numPlates  = parseInt(document.getElementById('param-plates')?.value  || 7);
+        const co2        = parseFloat(document.getElementById('param-co2')?.value   || 400);
+        const seed       = parseInt(document.getElementById('param-seed')?.value    || 42);
+        const timestepMa = parseFloat(document.getElementById('param-timestep')?.value || 10);
 
-        // Gather params from sidebar
-        const timeMa    = parseFloat(document.getElementById('param-time')?.value    || 500);
-        const seed      = parseInt  (document.getElementById('param-seed')?.value    || 42);
-        const co2       = parseFloat(document.getElementById('param-co2')?.value     || 400);
-        const numPlates = parseInt  (document.getElementById('param-plates')?.value  || 7);
-
-        // Start progress polling
-        this._startProgressPoll();
+        const btn = document.getElementById('btn-sim-init');
+        if (btn) { btn.disabled = true; btn.textContent = '⏳ Initialising…'; }
 
         try {
-            const result = await API.simulate({
+            const result = await API.simInit({
                 continental_cells: this._globe.getPaintedCells('continental'),
                 craton_cells:      this._globe.getPaintedCells('craton'),
-                rift_cells:        this._globe.getPaintedCells('rift'),
-                time_ma:    timeMa,
+                rift_edges:        this._globe.getRiftEdges(),
                 seed,
-                co2_ppm:    co2,
-                num_plates: numPlates,
+                co2_ppm:     co2,
+                num_plates:  numPlates,
+                grid_level:  7,
+                timestep_ma: timestepMa,
             });
 
-            this._stopProgressPoll();
+            this._snapshots   = [{ time_ma: 0, result }];
+            this._snapshotIdx = 0;
+            this._initialized = true;
+
             this._globe.applySimResult(result);
             this._setColorMode('elevation');
+
+            document.getElementById('timeline-section').style.display = 'block';
+            this._updateTimelineUI();
+            this._updateStatus('Initialised — Step or Play to advance');
             this._updateSimStats(result);
-            this._updateStatus(`Simulation complete — ${timeMa} Ma simulated`);
+            document.getElementById('sim-stats-section').style.display = 'block';
 
         } catch (err) {
-            this._stopProgressPoll();
-            this._updateStatus(`Error: ${err.message}`);
-            alert(`Simulation failed:\n${err.message}`);
+            this._updateStatus('Init error: ' + err.message);
+            alert('Init failed: ' + err.message);
+        } finally {
+            if (btn) { btn.disabled = false; btn.textContent = '⚙ Initialise'; }
+        }
+    }
+
+    async _stepForward() {
+        if (!this._initialized || this._running) return;
+        this._running = true;
+        const btn = document.getElementById('btn-step-fwd');
+        if (btn) btn.disabled = true;
+        try {
+            const result = await API.simStep(1);
+            this._snapshots.push({ time_ma: result.current_time_ma, result });
+            this._snapshotIdx = this._snapshots.length - 1;
+            this._globe.applySimResult(result);
+            this._updateTimelineUI();
+            this._updateSimStats(result);
+            this._updateStatus(`${result.current_time_ma} Ma — ${result.boundaries?.length || 0} boundary segments`);
+        } catch (err) {
+            this._updateStatus('Step error: ' + err.message);
+            this._stopPlay();
         } finally {
             this._running = false;
-            this._setSimRunning(false);
+            if (btn) btn.disabled = false;
         }
     }
 
-    _setSimRunning(running) {
-        const btn = document.getElementById('btn-simulate');
-        if (btn) {
-            btn.disabled = running;
-            btn.textContent = running ? '⏳ Running…' : '▶ Run Simulation';
+    _stepBack() {
+        if (this._snapshotIdx > 0) {
+            this._setSnapshotIdx(this._snapshotIdx - 1);
         }
-        const wrap = document.getElementById('sim-progress-wrap');
-        if (wrap) wrap.classList.toggle('visible', running);
     }
 
-    _startProgressPoll() {
-        this._polling = setInterval(async () => {
-            const status = await API.getStatus().catch(() => null);
-            if (!status) return;
-            const pct = Math.round(status.progress * 100);
-            const fill = document.getElementById('progress-fill');
-            const text = document.getElementById('progress-text');
-            if (fill) fill.style.width = pct + '%';
-            if (text) text.textContent = `${Math.round(status.current_time)} / ${Math.round(status.max_time)} Ma`;
-        }, 500);
+    _togglePlay() {
+        if (this._playing) {
+            this._stopPlay();
+        } else {
+            this._startPlay();
+        }
     }
 
-    _stopProgressPoll() {
-        clearInterval(this._polling);
-        this._polling = null;
-        const fill = document.getElementById('progress-fill');
-        const text = document.getElementById('progress-text');
-        if (fill) fill.style.width = '100%';
-        if (text) text.textContent = 'Complete';
+    _startPlay() {
+        if (!this._initialized) return;
+        this._playing = true;
+        const btn = document.getElementById('btn-play-pause');
+        if (btn) btn.textContent = '⏸';
+        this._playInterval = setInterval(() => {
+            if (!this._running) this._stepForward();
+        }, 800);
+    }
+
+    _stopPlay() {
+        this._playing = false;
+        clearInterval(this._playInterval);
+        this._playInterval = null;
+        const btn = document.getElementById('btn-play-pause');
+        if (btn) btn.textContent = '▶';
+    }
+
+    _setSnapshotIdx(idx) {
+        if (idx < 0 || idx >= this._snapshots.length) return;
+        this._snapshotIdx = idx;
+        const snap = this._snapshots[idx];
+        this._globe.applySimResult(snap.result);
+        this._updateTimelineUI();
+        this._updateSimStats(snap.result);
+        this._updateStatus(`Viewing ${snap.time_ma} Ma`);
+    }
+
+    _finaliseState() {
+        if (this._snapshotIdx < 0) return;
+        this._stopPlay();
+        const snap = this._snapshots[this._snapshotIdx];
+        this._globe.applySimResult(snap.result);
+        this._setColorMode('elevation');
+        document.getElementById('sim-stats-section').style.display = 'block';
+        this._updateSimStats(snap.result);
+        this._updateStatus(`Finalised at ${snap.time_ma} Ma`);
+    }
+
+    _updateTimelineUI() {
+        const snap = this._snapshots[this._snapshotIdx];
+        if (!snap) return;
+        const el = document.getElementById('tl-time');
+        if (el) el.textContent = `${snap.time_ma} Ma`;
+        const slider = document.getElementById('timeline-slider');
+        if (slider) {
+            slider.max   = String(this._snapshots.length - 1);
+            slider.value = String(this._snapshotIdx);
+        }
     }
 
     // ── Stats display ─────────────────────────────────────────────────────────
@@ -355,6 +433,7 @@ class GeoForgeUI {
                 case 'r': this._setTool('rift');          break;
                 case ' ': e.preventDefault(); this._setTool('orbit'); break;
                 case 'g': this._globe.toggleWireframe();  break;
+                case 'p': this._togglePlay(); break;
                 case '[': this._globe.setBrushRadius(this._globe.getBrushRadius()-1);
                           this._updateBrushIndicator(); break;
                 case ']': this._globe.setBrushRadius(this._globe.getBrushRadius()+1);

--- a/src/web/ui.js
+++ b/src/web/ui.js
@@ -87,6 +87,13 @@ class GeoForgeUI {
             this._globe._controls.target.set(0, 0, 0);
             this._globe._controls.update();
         });
+
+        document.getElementById('btn-boundaries')?.addEventListener('click', () => {
+            const btn = document.getElementById('btn-boundaries');
+            const on  = !btn.classList.contains('active');
+            btn.classList.toggle('active', on);
+            this._globe.toggleBoundaries(on);
+        });
     }
 
     _setColorMode(mode) {
@@ -358,6 +365,7 @@ class GeoForgeUI {
                 case '4': this._setColorMode('precipitation'); break;
                 case '5': this._setColorMode('koppen');        break;
                 case '6': this._setColorMode('plates');        break;
+                case 'b': document.getElementById('btn-boundaries')?.click(); break;
             }
         });
 

--- a/src/web/ui.js
+++ b/src/web/ui.js
@@ -7,9 +7,10 @@
 
 class GeoForgeUI {
     constructor(globe) {
-        this._globe    = globe;
-        this._polling  = null;   // setInterval handle for progress polling
-        this._running  = false;
+        this._globe      = globe;
+        this._polling    = null;   // setInterval handle for progress polling
+        this._running    = false;
+        this._errorTimer = null;
     }
 
     init() {
@@ -238,6 +239,19 @@ class GeoForgeUI {
     _bindGlobeCallbacks() {
         this._globe.onPaintChanged = () => this._updateStats();
         this._globe.onCellHover = (idx, lat, lon) => this._updateTooltip(idx, lat, lon);
+        this._globe.onContiguityError = (msg) => this._flashError(msg);
+    }
+
+    _flashError(msg) {
+        const el = document.getElementById('sb-status');
+        if (!el) return;
+        el.textContent = '⚠ ' + msg;
+        el.style.color = '#ff6644';
+        clearTimeout(this._errorTimer);
+        this._errorTimer = setTimeout(() => {
+            el.style.color = '';
+            el.textContent = 'Ready';
+        }, 3000);
     }
 
     _updateStats() {
@@ -246,7 +260,9 @@ class GeoForgeUI {
 
         this._setStatValue('stat-total',    s.total.toLocaleString());
         this._setStatValue('stat-cont',     `${s.continental.toLocaleString()} (${pct.toFixed(1)}%)`);
-        this._setStatValue('stat-cratons',  s.craton.toLocaleString());
+        this._setStatValue('stat-cratons',  s.craton_regions !== undefined
+            ? `${s.craton_regions} region${s.craton_regions !== 1 ? 's' : ''}`
+            : s.craton.toLocaleString());
         this._setStatValue('stat-rift',     s.rift.toLocaleString());
 
         // Statusbar

--- a/src/web/ui.js
+++ b/src/web/ui.js
@@ -81,13 +81,6 @@ class GeoForgeUI {
             });
         });
 
-        // Reset view button
-        document.getElementById('btn-reset-view')?.addEventListener('click', () => {
-            this._globe._camera.position.set(0, 0, 2.8);
-            this._globe._controls.target.set(0, 0, 0);
-            this._globe._controls.update();
-        });
-
         document.getElementById('btn-boundaries')?.addEventListener('click', () => {
             const btn = document.getElementById('btn-boundaries');
             const on  = !btn.classList.contains('active');
@@ -355,10 +348,10 @@ class GeoForgeUI {
             b.textContent = pct.toFixed(1) + '%';
         });
         document.getElementById('sb-cratons')?.querySelectorAll('b').forEach(b => {
-            b.textContent = s.craton;
+            b.textContent = s.craton_regions !== undefined ? s.craton_regions : s.craton;
         });
         document.getElementById('sb-rift')?.querySelectorAll('b').forEach(b => {
-            b.textContent = s.rift + ' cells';
+            b.textContent = s.rift + ' edges';
         });
     }
 


### PR DESCRIPTION
## Summary

- **Level-7 geodesic grid** (163k cells, up from 40k) with full edge topology exported to frontend
- **Step-by-step simulation API** (`/api/sim/init`, `/api/sim/step`, `/api/sim/reset`) — server holds session state so the frontend can advance one timestep at a time
- **Wilson Cycle auto-rift** — BFS assembly index triggers automatic rifting when >70% of continental cells form one cluster for 200+ Ma; ~500 Ma full cycle
- **Rift edge drawing tool** — rifts drawn as red lines on cell boundaries (not painted cells); zoom-aware pick threshold
- **Contiguous continent enforcement** — painting disconnected land masses raises an error; craton count = BFS region count (not raw cell count) with dirty-flag cache
- **Boundary visualization** — ridge/subduction/transform/collision rendered as vertex-colored LineSegments during simulation
- **Timeline UI** — step forward/back, play/pause (P), snapshot scrubbing, "Use This State" early termination; `_snapshots[]` cache for instant rewind without re-simulation

## Test Plan

- [ ] `pytest src/grid/test_geodesic_grid.py -v` — all 9 tests pass
- [ ] Start server, open UI, paint a supercontinent, initialise simulation
- [ ] Step forward — globe updates elevation; boundary lines appear
- [ ] Play — simulation advances automatically every 800ms
- [ ] Scrub timeline slider — globe restores cached snapshot instantly
- [ ] "Use This State" — timeline hides, result is finalised
- [ ] Draw rift edges on cell boundaries — red lines appear; toggle off by clicking again
- [ ] Try painting disconnected land — error flash appears in status bar
- [ ] Toggle `⚡ Boundaries` — boundary lines show/hide

## Commits

```
78e7ac5 fix: address all code review issues (race condition, boundary classification, misc)
294fe67 feat: timeline UI with step/play/pause, snapshot scrubbing, Use This State
d6a18db feat: boundary visualization (ridges/subduction/transforms as colored lines)
aa933d7 fix: cache craton regions, scale edge pick threshold with zoom, hide hover on tool switch
04c5ab5 feat: contiguous continent enforcement + craton region counting
34f64ae feat: rift edge drawing tool (draw on cell boundaries, rendered as red lines)
a999e09 fix: deterministic auto-rift seed, cap plate IDs at uint8 max
99e3486 feat: Wilson Cycle auto-rift + boundary output from simulation steps
18eb42d feat: add step-by-step sim API (/api/sim/init, /api/sim/step, /api/sim/reset)
724cb6f feat: upgrade to level-7 grid (163k cells) + export edge topology
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive step-by-step simulation with timeline controls (play, pause, step forward/back, timeline slider)
  * Boundary event visualization during simulation results
  * Edge-based rift editing replacing cell-based painting
  * Contiguity enforcement: continental and craton regions must connect to existing landmasses

* **Improvements**
  * Higher default grid resolution for increased spatial detail
  * New timestep parameter for finer simulation control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->